### PR TITLE
another fix to auto publishing binary artifacts

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -240,4 +240,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} './${{ needs.parse_tag.outputs.crate_name }}/${{ steps.set_output.outputs.archive }}'
+          gh release upload ${{ github.event.release.tag_name }} '${{ steps.set_output.outputs.archive }}'

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ninja-xtask"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "autocfg",
  "clap",

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-xtask"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 readme = "README.md"
 description = "xtask utilities that I use in most projects"


### PR DESCRIPTION
fix path where gh cli looks for the archive