### PR TITLE
Fix missing bins

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -181,7 +181,12 @@ jobs:
       - name: install build tooling
         uses: taiki-e/install-action@v2
         with:
-          tool: "cargo-zigbuild,ninja-xtask,cargo-about"
+          tool: "cargo-zigbuild,cargo-about"
+
+      - name: install binstallable ninja 
+        uses: taiki-e/install-action@v2
+        with:
+          tool: ninja-xtask@0.2.2
 
       - name: build ${{ matrix.target }} ${{ matrix.glibc }} --release
         run: cargo ninja build --target=${{ matrix.target }} ${{ matrix.glibc }} --release

--- a/ninja-xtask/CHANGELOG.md
+++ b/ninja-xtask/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog ninja-xtask
 
-## v0.2.4
+## v0.2.4 & 0.2.5
 
 - fix build workflow for publishing binaries
 

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -352,7 +352,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ninja-xtask"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "autocfg",
  "clap",

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-xtask"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 readme = "README.md"
 description = "xtask utilities that I use in most projects"


### PR DESCRIPTION
- temporarily use v0.2.2 which has published binaries, so we can binstall self in CI. (taiki uses stable chain for fallback and we don't compile with that)