### PR TITLE
ninja-build_rs v0.3.0 & ninja-xtask v 0.3.0

### DIFF
--- a/ninja-build_rs/Cargo.toml
+++ b/ninja-build_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-build_rs"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 readme = "README.md"
 description = "build script helpers for working with nightly"

--- a/ninja-build_rs/Cargo.toml
+++ b/ninja-build_rs/Cargo.toml
@@ -14,5 +14,8 @@ license = "MIT"
 [dependencies]
 autocfg = "1.5.1"
 
+derive_more.version = "2.1.1"
+derive_more.features = ["display"]
+
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/ninja-build_rs/Cargo.toml
+++ b/ninja-build_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-build_rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 readme = "README.md"
 description = "build script helpers for working with nightly"

--- a/ninja-build_rs/README.md
+++ b/ninja-build_rs/README.md
@@ -1,6 +1,6 @@
 # ninja-build_rs
 
-Designed to help create good build scripts, with a focus on ease-of-use of you,
+Designed to help create good build scripts, with a focus on ease of use for you,
 valuable output in `cargo build -vv` & no annoying surprises for anyone downstream.
 
 ## Prelude

--- a/ninja-build_rs/README.md
+++ b/ninja-build_rs/README.md
@@ -1,7 +1,21 @@
-# ninja-build
+# ninja-build_rs
 
-A collection of things I regularly find I need in my build.rs including
+Designed to help create good build scripts, with a focus on ease-of-use of you,
+valuable output in `cargo build -vv` & no annoying surprises for anyone downstream.
 
-- A Result/Error that gives meaningful output if used in `main() -> Result<()>`
-- Get an env var and provide a useful message if it does not exist
-- Handling the stabilisation lifecycle of experimental features when using nightly
+## Prelude
+
+```rust
+use ninja_build_rs::prelude::*;
+```
+
+provides:
+
+- A [`Result`] alias & [`BuildError`] type that gives meaningful output from `main() -> Result<()>`.
+- [`get_var()`] & [`split_var()`] which automatically register `cargo::rerun-if-env-changed`
+  and include the variable name in any errors.
+- [`emit_unstable_feature()`](nightly::Nightly::emit_unstable_feature),
+  [`cargo_allowed_features`](nightly::cargo_allowed_features) &
+  enum [`UnstableFeature`](nightly::UnstableFeature) to provide a safe way to identify the
+  availability of nightly features & handle the future stabilisation process without additional
+  effort on your part. All while respecting any `allow-feature` whitelists.

--- a/ninja-build_rs/examples/assert_matches/build.rs
+++ b/ninja-build_rs/examples/assert_matches/build.rs
@@ -1,12 +1,9 @@
 use autocfg::AutoCfg;
-use ninja_build_rs::{
-    Result,
-    nightly::{Nightly, cargo_allowed_features},
-};
+use ninja_build_rs::prelude::*;
 
 fn main() -> Result<()> {
     let ac = AutoCfg::new()?;
     let allowed_features = cargo_allowed_features()?;
-    ac.emit_unstable_feature("assert_matches", &allowed_features);
+    ac.emit_unstable_feature(assert_matches, &allowed_features);
     Ok(())
 }

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -6,6 +6,12 @@ use std::{collections::HashSet, env::VarError, ffi::OsString};
 
 pub mod nightly;
 
+/// Prelude to allow `use ninja-build_rs::prelude::*`
+pub mod prelude {
+    pub use crate::nightly::{Nightly, UnstableFeature::*, cargo_allowed_features};
+    pub use crate::{Result, get_var, split_var};
+}
+
 /// Result type wrapping [BuildError]. Returning this from `main` in a build script will
 /// provide useful information in the debug representation sent to stderr on failure.
 pub type Result<T> = std::result::Result<T, BuildError>;

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -1,7 +1,22 @@
-//! A collection of things I regularly find I need in my build.rs including
-//! - A Result/Error that gives meaningful output if used in `main() -> Result<()>`
-//! - Get an env var and provide a useful message if it does not exist
-//! - Handling the stabilisation lifecycle of experimental features when using nightly
+//! Designed to help create good build scripts, with a focus on ease-of-use of you,
+//! valuable output in `cargo build -vv` & no annoying surprises for anyone downstream.
+//!
+//! ## Prelude
+//!
+//! ```rust
+//! use ninja_build_rs::prelude::*;
+//! ```
+//!
+//! provides:
+//!
+//! - A [`Result`] alias & [`BuildError`] type that gives meaningful output from `main() -> Result<()>`.
+//! - [`get_var()`] & [`split_var()`] which automatically register `cargo::rerun-if-env-changed`
+//!   and include the variable name in any errors.
+//! - [`emit_unstable_feature()`](nightly::Nightly::emit_unstable_feature),
+//!   [`cargo_allowed_features`](nightly::cargo_allowed_features) &
+//!   enum [`UnstableFeature`](nightly::UnstableFeature) to provide a safe way to identify the
+//!   availability of nightly features & handle the future stabilisation process without additional
+//!   effort on your part. All while respecting any `allow-feature` whitelists.
 use std::{collections::HashSet, env::VarError, ffi::OsString};
 
 pub mod nightly;

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -19,8 +19,6 @@
 //!   effort on your part. All while respecting any `allow-feature` whitelists.
 use std::{collections::HashSet, env::VarError, ffi::OsString};
 
-pub mod nightly;
-
 /// Recommended prelude: `use ninja-build_rs::prelude::*`
 ///
 /// - A [`Result`] alias & [`BuildError`] type that gives meaningful output from `main() -> Result<()>`.
@@ -36,9 +34,7 @@ pub mod prelude {
     pub use crate::{Result, get_var, split_var};
 }
 
-/// Result type wrapping [BuildError]. Using `main() -> Result<()>` in `build.rs` will
-/// provide useful information in the debug representation sent to stderr on failure.
-pub type Result<T> = std::result::Result<T, BuildError>;
+pub mod nightly;
 
 /// Attempt to get an environment variable.
 ///
@@ -48,6 +44,7 @@ pub fn get_var(key: &str) -> Result<String> {
     println!("cargo::rerun-if-env-changed={key}");
     std::env::var(key).map_err(|err| BuildError::from_var_error(key, err))
 }
+
 /// Attempt to get an environment variable and split the values using the OS path separator.
 ///
 /// - Emits `cargo::rerun-if-env-changed=key` to ensure changes trigger a rebuild.
@@ -57,6 +54,10 @@ pub fn split_var(key: &str) -> Result<HashSet<String>> {
         .map(|p| p.to_string_lossy().to_string())
         .collect())
 }
+
+/// Result type wrapping [BuildError]. Using `main() -> Result<()>` in `build.rs` will
+/// provide useful information in the debug representation sent to stderr on failure.
+pub type Result<T> = std::result::Result<T, BuildError>;
 
 #[derive(Debug)]
 /// An error designed to have nice debug representations for common errors encountered

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -21,13 +21,22 @@ use std::{collections::HashSet, env::VarError, ffi::OsString};
 
 pub mod nightly;
 
-/// Prelude to allow `use ninja-build_rs::prelude::*`
+/// Recommended prelude: `use ninja-build_rs::prelude::*`
+///
+/// - A [`Result`] alias & [`BuildError`] type that gives meaningful output from `main() -> Result<()>`.
+/// - [`get_var()`] & [`split_var()`] which automatically register `cargo::rerun-if-env-changed`
+///   and include the variable name in any errors.
+/// - [`emit_unstable_feature()`](nightly::Nightly::emit_unstable_feature),
+///   [`cargo_allowed_features`](nightly::cargo_allowed_features) &
+///   enum [`UnstableFeature`](nightly::UnstableFeature) to provide a safe way to identify the
+///   availability of nightly features & handle the future stabilisation process without additional
+///   effort on your part. All while respecting any `allow-feature` whitelists.
 pub mod prelude {
     pub use crate::nightly::{Nightly, UnstableFeature::*, cargo_allowed_features};
     pub use crate::{Result, get_var, split_var};
 }
 
-/// Result type wrapping [BuildError]. Returning this from `main` in a build script will
+/// Result type wrapping [BuildError]. Using `main() -> Result<()>` in `build.rs` will
 /// provide useful information in the debug representation sent to stderr on failure.
 pub type Result<T> = std::result::Result<T, BuildError>;
 
@@ -53,9 +62,21 @@ pub fn split_var(key: &str) -> Result<HashSet<String>> {
 /// An error designed to have nice debug representations for common errors encountered
 /// in build.rs
 pub enum BuildError {
+    /// If an environment variable was requested but not set
+    ///
+    /// outputs `VarNotSet("KEY")` to stderr
     VarNotSet(OsString),
+    /// If an environment variable contains non-unicode characters
+    ///
+    /// outputs `VarInvalid("KEY", "contents")` to stderr
     VarInvalid(OsString, OsString),
+    /// An IO Error occurred
+    ///
+    /// outputs `IOError(error details)` to stderr
     IOError(std::io::Error),
+    /// Catch-all for any other error
+    ///
+    /// outputs `Other(some text)` to stderr
     Other(String),
 }
 
@@ -110,6 +131,7 @@ mod tests {
     fn missing_env_var() {
         let random_key = "019de8d0-bb66-769d-9d4d-fec48aebdd49";
         let err = get_var(random_key);
+        dbg!(&err);
         assert!(err.is_err());
         assert!(format!("{err:?}").contains(random_key));
     }

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! Designed to help create good build scripts, with a focus on ease-of-use of you,
+//! Designed to help create good build scripts, with a focus on ease of use for you,
 //! valuable output in `cargo build -vv` & no annoying surprises for anyone downstream.
 //!
 //! ## Prelude

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -81,7 +81,7 @@ pub enum BuildError {
 }
 
 impl BuildError {
-    /// Ensure that the key name is included in the error returned.
+    /// Create a `BuildError` from a `VarError` for a given key.
     /// You probably won't need this often and can use [get_var] for most cases.
     pub fn from_var_error(key: &str, err: VarError) -> BuildError {
         match err {
@@ -104,12 +104,13 @@ impl From<std::io::Error> for BuildError {
 }
 
 /// Generate your own with `Err("some text")`
-impl From<&'static str> for BuildError {
-    fn from(msg: &'static str) -> Self {
+impl From<&str> for BuildError {
+    fn from(msg: &str) -> Self {
         msg.to_string().into()
     }
 }
 
+/// Generate your own with `Err(String)`
 impl From<String> for BuildError {
     fn from(msg: String) -> Self {
         BuildError::Other(msg)

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -75,6 +75,10 @@ pub enum BuildError {
     ///
     /// outputs `IOError(error details)` to stderr
     IOError(std::io::Error),
+    /// An error when creating or using [AutoCfg]
+    ///
+    /// outputs `AutoCfgError(error details)`
+    AutoCfgError(autocfg::Error),
     /// Catch-all for any other error
     ///
     /// outputs `Other(some text)` to stderr
@@ -94,7 +98,7 @@ impl BuildError {
 
 impl From<autocfg::Error> for BuildError {
     fn from(e: autocfg::Error) -> Self {
-        BuildError::Other(e.to_string())
+        BuildError::AutoCfgError(e)
     }
 }
 

--- a/ninja-build_rs/src/lib.rs
+++ b/ninja-build_rs/src/lib.rs
@@ -30,7 +30,7 @@ use std::{collections::HashSet, env::VarError, ffi::OsString};
 ///   availability of nightly features & handle the future stabilisation process without additional
 ///   effort on your part. All while respecting any `allow-feature` whitelists.
 pub mod prelude {
-    pub use crate::nightly::{Nightly, UnstableFeature::*, cargo_allowed_features};
+    pub use crate::nightly::{AutoCfg, Nightly, UnstableFeature::*, cargo_allowed_features};
     pub use crate::{Result, get_var, split_var};
 }
 

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -29,8 +29,8 @@ pub enum UnstableFeature {
     OtherFeature(String),
 }
 
-impl From<&'static str> for UnstableFeature {
-    fn from(feature: &'static str) -> Self {
+impl From<&str> for UnstableFeature {
+    fn from(feature: &str) -> Self {
         match feature {
             "assert_matches" => Self::assert_matches,
             "iterator_try_collect" => Self::iterator_try_collect,
@@ -46,9 +46,9 @@ impl From<&'static str> for UnstableFeature {
 mod probes {
     use autocfg::AutoCfg;
 
-use crate::nightly::UnstableFeature;
+    use crate::nightly::UnstableFeature;
 
-    pub fn make_probe(feature: UnstableFeature, allowed: bool, probe: &str) -> String {
+    pub fn make_probe(feature: &UnstableFeature, allowed: bool, probe: &str) -> String {
         let mut _probe = String::with_capacity(256);
         if allowed {
             _probe.push('\n');
@@ -66,7 +66,7 @@ use crate::nightly::UnstableFeature;
         _probe
     }
 
-    pub fn has(ac: &AutoCfg, feature: UnstableFeature, allowed: bool, probe: &str) {
+    pub fn has(ac: &AutoCfg, feature: &UnstableFeature, allowed: bool, probe: &str) {
         let cfg = format!("has_{feature}");
         autocfg::emit_possibility(&cfg);
         let code = make_probe(feature, allowed, probe);
@@ -161,7 +161,7 @@ pub trait Nightly {
     fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures);
 }
 
-fn default_unstable_cfg(ac: &AutoCfg, feature: UnstableFeature, allowed: bool) {
+fn default_unstable_cfg(ac: &AutoCfg, feature: &UnstableFeature, allowed: bool) {
     let cfg = format!("unstable_{feature}");
     autocfg::emit_possibility(&cfg);
 
@@ -186,14 +186,14 @@ impl Nightly for AutoCfg {
         dbg!(&feature);
 
         let ac = self;
-        let allowed = allowed_features.includes(feature);
-        match UnstableFeature::from(feature) {
+        let allowed = allowed_features.includes(&feature);
+        match feature {
             UnstableFeature::assert_matches => {
-                default_unstable_cfg(self, feature, allowed);
-                has(ac, feature, allowed, probes::assert_matches::AVAILABLE);
+                default_unstable_cfg(self, &feature, allowed);
+                has(ac, &feature, allowed, probes::assert_matches::AVAILABLE);
                 autocfg::emit_possibility("assert_matches_location, values(\"root\", \"module\")");
                 if self
-                    .probe_raw(&make_probe(feature, allowed, probes::assert_matches::ROOT))
+                    .probe_raw(&make_probe(&feature, allowed, probes::assert_matches::ROOT))
                     .is_ok()
                 {
                     autocfg::emit("assert_matches_location=\"root\"")
@@ -203,17 +203,17 @@ impl Nightly for AutoCfg {
                 }
             }
             UnstableFeature::iterator_try_collect => {
-                default_unstable_cfg(self, feature, allowed);
+                default_unstable_cfg(self, &feature, allowed);
                 has(
                     ac,
-                    feature,
+                    &feature,
                     allowed,
                     probes::iterator_try_collect::AVAILABLE,
                 );
             }
             UnstableFeature::never_type => {
-                default_unstable_cfg(self, feature, allowed);
-                has(ac, feature, allowed, probes::never_type::AVAILABLE);
+                default_unstable_cfg(self, &feature, allowed);
+                has(ac, &feature, allowed, probes::never_type::AVAILABLE);
             }
             UnstableFeature::proc_macro_diagnostic => {
                 autocfg::emit_possibility("unstable_proc_macro_diagnostic");
@@ -226,25 +226,25 @@ impl Nightly for AutoCfg {
                 }
                 has(
                     ac,
-                    feature,
+                    &feature,
                     allowed,
                     probes::proc_macro_diagnostic::AVAILABLE,
                 );
             }
             UnstableFeature::try_trait_v2 => {
-                default_unstable_cfg(self, feature, allowed);
-                has(ac, feature, allowed, probes::try_trait_v2::AVAILABLE);
+                default_unstable_cfg(self, &feature, allowed);
+                has(ac, &feature, allowed, probes::try_trait_v2::AVAILABLE);
             }
             UnstableFeature::try_trait_v2_residual => {
-                default_unstable_cfg(self, feature, allowed);
+                default_unstable_cfg(self, &feature, allowed);
                 has(
                     ac,
-                    feature,
+                    &feature,
                     allowed,
                     probes::try_trait_v2_residual::AVAILABLE,
                 );
             }
-            UnstableFeature::OtherFeature(_) => default_unstable_cfg(self, feature, allowed),
+            UnstableFeature::OtherFeature(_) => default_unstable_cfg(self, &feature, allowed),
         }
     }
 }
@@ -366,7 +366,7 @@ fn _cargo_allowed_features<P: AsRef<Path>>(current_dir: Option<P>) -> Result<All
                 .split(",")
                 .map(str::trim)
                 .filter(|feature| !added_unstable_options || *feature != "unstable-options")
-                .map(ToString::to_string)
+                .map(UnstableFeature::from)
                 .collect();
             if features.is_empty() {
                 AllowedFeatures(_AllowedFeatures::None)
@@ -391,7 +391,7 @@ pub struct AllowedFeatures(_AllowedFeatures);
 impl AllowedFeatures {
     /// Not public as this doesn't consider any restrictions made via `RUSTFLAGS`, those
     /// features will be disabled for all calls to rustc when running probes.
-    fn includes(&self, feature: &str) -> bool {
+    fn includes(&self, feature: &UnstableFeature) -> bool {
         match &self.0 {
             _AllowedFeatures::None => false,
             _AllowedFeatures::All => true,
@@ -404,7 +404,7 @@ impl AllowedFeatures {
 enum _AllowedFeatures {
     None,
     All,
-    Some(Vec<String>),
+    Some(Vec<UnstableFeature>),
 }
 
 #[cfg(test)]
@@ -417,6 +417,7 @@ mod tests {
 
     use tempfile::TempDir;
 
+    use super::UnstableFeature::*;
     use super::*;
 
     #[test]
@@ -425,10 +426,10 @@ mod tests {
         let allowed = _cargo_allowed_features(Some(&tmp));
         if cargo_unstable().expect("cargo_unstable") {
             assert_matches!(allowed, Ok(AllowedFeatures(_AllowedFeatures::All)));
-            assert!(allowed.unwrap().includes("try_trait_v2"));
+            assert!(allowed.unwrap().includes(&try_trait_v2));
         } else {
             assert_matches!(allowed, Ok(AllowedFeatures(_AllowedFeatures::None)));
-            assert!(!allowed.unwrap().includes("try_trait_v2"));
+            assert!(!allowed.unwrap().includes(&try_trait_v2));
         }
     }
 
@@ -451,14 +452,14 @@ mod tests {
             assert_matches!(
                 allowed,
                 AllowedFeatures(_AllowedFeatures::Some(ref features))
-                if features == &vec!["try_trait_v2", "unstable-options"]
+                if features == &vec![try_trait_v2, OtherFeature("unstable-options".to_string())]
             );
-            assert!(allowed.includes("try_trait_v2"));
-            assert!(allowed.includes("unstable-options"));
+            assert!(allowed.includes(&try_trait_v2));
+            assert!(allowed.includes(&OtherFeature("unstable-options".to_string())));
         } else {
             assert_matches!(allowed, AllowedFeatures(_AllowedFeatures::None));
-            assert!(!allowed.includes("try_trait_v2"));
-            assert!(!allowed.includes("unstable-options"));
+            assert!(!allowed.includes(&try_trait_v2));
+            assert!(!allowed.includes(&OtherFeature("unstable-options".to_string())));
         }
     }
 
@@ -477,12 +478,12 @@ mod tests {
             assert_matches!(
                 allowed,
                 AllowedFeatures(_AllowedFeatures::Some(ref features))
-                if features == &vec!["try_trait_v2"]
+                if features == &vec![try_trait_v2]
             );
-            assert!(allowed.includes("try_trait_v2"));
+            assert!(allowed.includes(&try_trait_v2));
         } else {
             assert_matches!(allowed, AllowedFeatures(_AllowedFeatures::None));
-            assert!(!allowed.includes("try_trait_v2"));
+            assert!(!allowed.includes(&try_trait_v2));
         }
     }
 
@@ -513,6 +514,6 @@ use std::assert_matches;
 use std::assert_matches;
 "#;
 
-        assert_eq!(probes::make_probe(UnstableFeature::assert_matches, true, probe), expected);
+        assert_eq!(probes::make_probe(&assert_matches, true, probe), expected);
     }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -1,6 +1,6 @@
 //! Checking for experimental or stabilised features is prone to subtle errors which create issues
 //! for downstream users and verbose when done properly. This provides extensions to the amazing
-//! [autocfg] (re-exported via our prelude to make your life easier) to safely identify the
+//! [autocfg::AutoCfg] (re-exported via our prelude to make your life easier) to safely identify the
 //! availability of nightly features & handle the future stabilisation process without additional
 //! effort on your part. All while respecting any `allow-feature` whitelists.
 //!

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -8,13 +8,14 @@ use std::{
 };
 
 use autocfg::AutoCfg;
+use derive_more::Display;
 
 use crate::{BuildError, Result, get_var};
 use probes::{has, make_probe};
 
 /// Known features with `unstable_...` & `has_...`
 #[allow(non_camel_case_types, reason = "shadowing feature naming")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum UnstableFeature {
     /// Also offers `assert_matches_location=root/module` to identify whether to
     /// `use std::assert_matches`(root) or `use std::assert_matches::assert_matches` (module)
@@ -45,7 +46,9 @@ impl From<&'static str> for UnstableFeature {
 mod probes {
     use autocfg::AutoCfg;
 
-    pub fn make_probe(feature: &str, allowed: bool, probe: &str) -> String {
+use crate::nightly::UnstableFeature;
+
+    pub fn make_probe(feature: UnstableFeature, allowed: bool, probe: &str) -> String {
         let mut _probe = String::with_capacity(256);
         if allowed {
             _probe.push('\n');
@@ -53,7 +56,7 @@ mod probes {
             _probe.push('\n');
 
             _probe.push_str("#![feature(");
-            _probe.push_str(feature);
+            _probe.push_str(&feature.to_string());
             _probe.push_str(")]");
             _probe.push('\n');
         };
@@ -63,7 +66,7 @@ mod probes {
         _probe
     }
 
-    pub fn has(ac: &AutoCfg, feature: &str, allowed: bool, probe: &str) {
+    pub fn has(ac: &AutoCfg, feature: UnstableFeature, allowed: bool, probe: &str) {
         let cfg = format!("has_{feature}");
         autocfg::emit_possibility(&cfg);
         let code = make_probe(feature, allowed, probe);
@@ -158,7 +161,7 @@ pub trait Nightly {
     fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures);
 }
 
-fn default_unstable_cfg(ac: &AutoCfg, feature: &'static str, allowed: bool) {
+fn default_unstable_cfg(ac: &AutoCfg, feature: UnstableFeature, allowed: bool) {
     let cfg = format!("unstable_{feature}");
     autocfg::emit_possibility(&cfg);
 
@@ -241,7 +244,7 @@ impl Nightly for AutoCfg {
                     probes::try_trait_v2_residual::AVAILABLE,
                 );
             }
-            UnstableFeature::OtherFeature(feature) => default_unstable_cfg(self, feature, allowed),
+            UnstableFeature::OtherFeature(_) => default_unstable_cfg(self, feature, allowed),
         }
     }
 }
@@ -510,6 +513,6 @@ use std::assert_matches;
 use std::assert_matches;
 "#;
 
-        assert_eq!(probes::make_probe("assert_matches", true, probe), expected);
+        assert_eq!(probes::make_probe(UnstableFeature::assert_matches, true, probe), expected);
     }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -13,7 +13,7 @@ use probes::{has, make_probe};
 
 /// Known features with `unstable_...` & `has_...`
 #[allow(non_camel_case_types, reason = "shadowing feature naming")]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnstableFeature {
     /// Also offers `assert_matches_location=root/module` to identify whether to
     /// `use std::assert_matches`(root) or `use std::assert_matches::assert_matches` (module)
@@ -24,7 +24,7 @@ pub enum UnstableFeature {
     try_trait_v2,
     try_trait_v2_residual,
     /// only provides `unstable_...` - please raise a PR to add a custom probe for `has_...`
-    OtherFeature(&'static str),
+    OtherFeature(String),
 }
 
 impl From<&'static str> for UnstableFeature {
@@ -36,7 +36,7 @@ impl From<&'static str> for UnstableFeature {
             "proc_macro_diagnostic" => Self::proc_macro_diagnostic,
             "try_trait_v2" => Self::try_trait_v2,
             "try_trait_v2_residual" => Self::try_trait_v2_residual,
-            _ => Self::OtherFeature(feature),
+            _ => Self::OtherFeature(feature.to_string()),
         }
     }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -362,6 +362,8 @@ impl Nightly for AutoCfg {
     }
 }
 
+/// Check whether cargo will accept unstable flags. You probably never need to run this
+/// yourself and should prefer to simply call [`cargo_allowed_features`].
 pub fn cargo_unstable() -> Result<bool> {
     Ok(Command::new(get_var("CARGO")?)
         .args([
@@ -514,6 +516,7 @@ impl AllowedFeatures {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// private to make it impossible to manually construct an [AllowedFeatures] from outside this crate
 enum _AllowedFeatures {
     None,
     All,

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -27,10 +27,25 @@ pub enum UnstableFeature {
     ///   use std::assert_matches::assert_matches;
     ///   ```
     assert_matches,
+    /// ### Provides cfg flags:
+    /// - `unstable_iterator_try_collect`
+    /// - `has_iterator_try_collect`
     iterator_try_collect,
+    /// ### Provides cfg flags:
+    /// - `unstable_never_type`
+    /// - `has_never_type`
     never_type,
+    /// ### Provides cfg flags:
+    /// - `unstable_proc_macro_diagnostic`
+    /// - `has_proc_macro_diagnostic`
     proc_macro_diagnostic,
+    /// ### Provides cfg flags:
+    /// - `unstable_try_trait_v2`
+    /// - `has_try_trait_v2`
     try_trait_v2,
+    /// ### Provides cfg flags:
+    /// - `unstable_try_trait_v2_residual`
+    /// - `has_try_trait_v2_residual`
     try_trait_v2_residual,
     /// only provides `unstable_...` - please raise a PR to add a custom probe for `has_...`
     OtherFeature(String),

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -24,7 +24,7 @@ pub enum UnstableFeature {
     try_trait_v2,
     try_trait_v2_residual,
     /// only provides `unstable_...` - please raise a PR to add a custom probe for `has_...`
-    Other(&'static str),
+    OtherFeature(&'static str),
 }
 
 impl From<&'static str> for UnstableFeature {
@@ -36,7 +36,7 @@ impl From<&'static str> for UnstableFeature {
             "proc_macro_diagnostic" => Self::proc_macro_diagnostic,
             "try_trait_v2" => Self::try_trait_v2,
             "try_trait_v2_residual" => Self::try_trait_v2_residual,
-            _ => Self::Other(feature),
+            _ => Self::OtherFeature(feature),
         }
     }
 }
@@ -238,7 +238,7 @@ impl Nightly for AutoCfg {
                     probes::try_trait_v2_residual::AVAILABLE,
                 );
             }
-            UnstableFeature::Other(feature) => default_unstable_cfg(self, feature, allowed),
+            UnstableFeature::OtherFeature(feature) => default_unstable_cfg(self, feature, allowed),
         }
     }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -17,8 +17,15 @@ use probes::{has, make_probe};
 #[allow(non_camel_case_types, reason = "shadowing feature naming")]
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum UnstableFeature {
-    /// Also offers `assert_matches_location=root/module` to identify whether to
-    /// `use std::assert_matches`(root) or `use std::assert_matches::assert_matches` (module)
+    /// ### Provides cfg flags:
+    /// - `unstable_assert_matches`
+    /// - `has_assert_matches`
+    /// - ```rust, ignore
+    ///   #[cfg(assert_matches_location = "root")]
+    ///   use std::assert_matches;
+    ///   #[cfg(assert_matches_location = "module")]
+    ///   use std::assert_matches::assert_matches;
+    ///   ```
     assert_matches,
     iterator_try_collect,
     never_type,

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -280,9 +280,9 @@ pub trait Nightly {
     /// - To be used at top-level crate via `#![cfg_attr(unstable_foo, feature(foo))]`
     ///
     /// ## Cfg-gating `has_...`
-    /// Do **not** rely on `cfg(not(unstable_foo))` to suggest that `feature(foo)` is stable! There are 3
-    /// reasons that `cfg(unstable_foo)` could be `false`:
-    ///   1. The build is using `stable`/`beta`
+    /// Do **not** rely on `cfg(not(unstable_foo))` to suggest that `feature(foo)` is stable! There
+    /// are 3 reasons that `cfg(unstable_foo)` could be `false`:
+    ///   1. The build is using `stable`/`beta` or the feature is not on the `allow-features` whitelist
     ///   2. The feature has been stabilised
     ///   3. The compiler is from before the feature was implemented
     ///

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -2,6 +2,7 @@
 //! experimental features in nightly.
 
 use std::{
+    fmt::Debug,
     path::Path,
     process::{Command, Output},
 };
@@ -154,7 +155,7 @@ pub trait Nightly {
     ///
     /// If you need to test that a feature is available in order to cfg-gate your code and it is not
     /// on the list of [known features](UnstableFeature), please raise a PR with a suggested probe.
-    fn emit_unstable_feature(&self, feature: &'static str, allowed_features: &AllowedFeatures);
+    fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures);
 }
 
 fn default_unstable_cfg(ac: &AutoCfg, feature: &'static str, allowed: bool) {
@@ -177,8 +178,10 @@ fn default_unstable_cfg(ac: &AutoCfg, feature: &'static str, allowed: bool) {
 }
 
 impl Nightly for AutoCfg {
-    fn emit_unstable_feature(&self, feature: &'static str, allowed_features: &AllowedFeatures) {
+    fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures) {
+        // show in `cargo build -vv`
         dbg!(&feature);
+
         let ac = self;
         let allowed = allowed_features.includes(feature);
         match UnstableFeature::from(feature) {

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -91,7 +91,7 @@ pub use autocfg::AutoCfg;
 use derive_more::Display;
 
 use crate::{BuildError, Result, get_var};
-use probes::{has, make_probe};
+use probes::{has, make_probe, unstable};
 
 /// Known features with `unstable_...` & `has_...`.
 ///
@@ -152,10 +152,12 @@ impl UnstableFeature {
 }
 
 mod probes {
-    use autocfg::AutoCfg;
+    use super::{AutoCfg, UnstableFeature};
 
-    use crate::nightly::UnstableFeature;
-
+    /// Prefix with:
+    /// - #![allow(stable_features)] (only if allowed)
+    /// - #![feature()] (only if allowed)
+    /// - #![allow(unused)] (always)
     pub fn make_probe(feature: &UnstableFeature, allowed: bool, probe: &str) -> String {
         let mut _probe = String::with_capacity(256);
         if allowed {
@@ -174,6 +176,7 @@ mod probes {
         _probe
     }
 
+    /// Register `#[cfg(has_feature)]` & set based on the probe
     pub fn has(ac: &AutoCfg, feature: &UnstableFeature, allowed: bool, probe: &str) {
         let cfg = format!("has_{feature}");
         autocfg::emit_possibility(&cfg);
@@ -183,8 +186,27 @@ mod probes {
         }
     }
 
-    pub mod assert_matches {
+    /// Register `#[cfg(has_feature)]` & run a default probe
+    pub fn unstable(ac: &AutoCfg, feature: &UnstableFeature, allowed: bool) {
+        let cfg = format!("unstable_{feature}");
+        autocfg::emit_possibility(&cfg);
 
+        if allowed {
+            let code = format!(
+                r#"
+#![deny(stable_features)]
+#![feature({feature})]
+#![allow(unused)]
+"#
+            );
+
+            if ac.probe_raw(&code).is_ok() {
+                autocfg::emit(&cfg);
+            }
+        }
+    }
+
+    pub mod assert_matches {
         pub const AVAILABLE: &str = r#"
 use std::assert_matches;
 "#;
@@ -195,7 +217,6 @@ fn main() {
     assert_matches!(Some(4), Some(_));
 }
 "#;
-
         // was stabilised in root - so no need to remove feature from this probe
         pub const MODULE: &str = r#"
 #![allow(stable_features)]
@@ -207,6 +228,7 @@ fn main() {
 }
 "#;
     }
+
     pub mod iterator_try_collect {
         // vec! not array: https://internals.rust-lang.org/t/code-compiles-on-playground-but-fails-when-passed-via-stdin-to-rustc/24393
         pub const AVAILABLE: &str = r#"
@@ -215,19 +237,21 @@ fn try_collect() {
 }
 "#;
     }
+
     pub mod never_type {
         pub const AVAILABLE: &str = r#"
 type Bang = !;
 "#;
     }
+
     pub mod proc_macro_diagnostic {
+        /// Special probe as feature only available in proc_macro context
         pub const UNSTABLE: &str = r#"
 #![deny(stable_features)]
 #![feature(proc_macro_diagnostic)]
 #![allow(unused)]
 extern crate proc_macro;
 "#;
-
         pub const AVAILABLE: &str = r#"
 extern crate proc_macro;
 use proc_macro::Diagnostic;      
@@ -269,25 +293,6 @@ pub trait Nightly {
     fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures);
 }
 
-fn default_unstable_cfg(ac: &AutoCfg, feature: &UnstableFeature, allowed: bool) {
-    let cfg = format!("unstable_{feature}");
-    autocfg::emit_possibility(&cfg);
-
-    if allowed {
-        let code = format!(
-            r#"
-#![deny(stable_features)]
-#![feature({feature})]
-#![allow(unused)]
-"#
-        );
-
-        if ac.probe_raw(&code).is_ok() {
-            autocfg::emit(&cfg);
-        }
-    }
-}
-
 impl Nightly for AutoCfg {
     fn emit_unstable_feature(&self, feature: UnstableFeature, allowed_features: &AllowedFeatures) {
         // show in `cargo build -vv`
@@ -297,7 +302,7 @@ impl Nightly for AutoCfg {
         let allowed = allowed_features.includes(&feature);
         match feature {
             UnstableFeature::assert_matches => {
-                default_unstable_cfg(self, &feature, allowed);
+                unstable(self, &feature, allowed);
                 has(ac, &feature, allowed, probes::assert_matches::AVAILABLE);
                 autocfg::emit_possibility("assert_matches_location, values(\"root\", \"module\")");
                 if self
@@ -311,7 +316,7 @@ impl Nightly for AutoCfg {
                 }
             }
             UnstableFeature::iterator_try_collect => {
-                default_unstable_cfg(self, &feature, allowed);
+                unstable(self, &feature, allowed);
                 has(
                     ac,
                     &feature,
@@ -320,7 +325,7 @@ impl Nightly for AutoCfg {
                 );
             }
             UnstableFeature::never_type => {
-                default_unstable_cfg(self, &feature, allowed);
+                unstable(self, &feature, allowed);
                 has(ac, &feature, allowed, probes::never_type::AVAILABLE);
             }
             UnstableFeature::proc_macro_diagnostic => {
@@ -340,11 +345,11 @@ impl Nightly for AutoCfg {
                 );
             }
             UnstableFeature::try_trait_v2 => {
-                default_unstable_cfg(self, &feature, allowed);
+                unstable(self, &feature, allowed);
                 has(ac, &feature, allowed, probes::try_trait_v2::AVAILABLE);
             }
             UnstableFeature::try_trait_v2_residual => {
-                default_unstable_cfg(self, &feature, allowed);
+                unstable(self, &feature, allowed);
                 has(
                     ac,
                     &feature,
@@ -352,7 +357,7 @@ impl Nightly for AutoCfg {
                     probes::try_trait_v2_residual::AVAILABLE,
                 );
             }
-            UnstableFeature::OtherFeature(_) => default_unstable_cfg(self, &feature, allowed),
+            UnstableFeature::OtherFeature(_) => unstable(self, &feature, allowed),
         }
     }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -10,7 +10,8 @@
 //!
 //! ### `build.rs`
 //!
-//! ```rust
+//! ```rust, ignore
+//! # use autocfg::AutoCfg;
 //! use ninja_build_rs::prelude::*;
 //!
 //! fn main() -> Result<()> {
@@ -94,7 +95,7 @@ use crate::{BuildError, Result, get_var};
 use probes::{has, make_probe};
 
 /// Known features with `unstable_...` & `has_...`.
-/// 
+///
 /// If the feature you want is not in this list you can use `Other` to get `unstable_...`
 /// but please also raise a PR (or open an issue) to add a custom probe for `has_...`.
 #[allow(non_camel_case_types, reason = "shadowing feature naming")]
@@ -136,7 +137,8 @@ pub enum UnstableFeature {
     OtherFeature(String),
 }
 
-impl From<&str> for UnstableFeature {
+impl UnstableFeature {
+    // This is not pub or trait From to avoid risk of typos
     fn from(feature: &str) -> Self {
         match feature {
             "assert_matches" => Self::assert_matches,

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -1,8 +1,8 @@
 //! Checking for experimental or stabilised features is prone to subtle errors which create issues
 //! for downstream users and verbose when done properly. This provides extensions to the amazing
-//! [autocfg] to safely identify the availability of nightly features & handle the future
-//! stabilisation process without additional effort on your part. All while respecting any
-//! `allow-feature` whitelists.
+//! [autocfg] (re-exported via our prelude to make your life easier) to safely identify the
+//! availability of nightly features & handle the future stabilisation process without additional
+//! effort on your part. All while respecting any `allow-feature` whitelists.
 //!
 //! For a list of known features with dedicated probes see [UnstableFeature]
 //!

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -1,5 +1,85 @@
-//! Extensions to the amazing [autocfg] designed to help with ergonomically and safely handling
-//! experimental features in nightly.
+//! Checking for experimental or stabilised features is prone to subtle errors which create issues
+//! for downstream users and verbose when done properly. This provides extensions to the amazing
+//! [autocfg] to safely identify the availability of nightly features & handle the future
+//! stabilisation process without additional effort on your part. All while respecting any
+//! `allow-feature` whitelists.
+//!
+//! For a list of known features with dedicated probes see [UnstableFeature]
+//!
+//! ## Usage
+//!
+//! ### `build.rs`
+//!
+//! ```rust
+//! use ninja_build_rs::prelude::*;
+//!
+//! fn main() -> Result<()> {
+//!     // get a new AutoCfg or provide a valuable error
+//!     // rather than panicing
+//!     let ac = AutoCfg::new()?;
+//!
+//!     // check to see if the downstream crate has defined
+//!     // `unstable.allow-features` in `.cargo/config.toml`.
+//!     // It is mandatory to perform this check and pass the
+//!     // result to any calls to `emit_unstable_feature`
+//!     let allowed_features = cargo_allowed_features()?;
+//!
+//!     // We want to make use of `assert_matches` if it is available
+//!     ac.emit_unstable_feature(assert_matches, &allowed_features);
+//!     //                       ^^^^^^^^^^^^^^ - enum variant to avoid typos
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### `lib.rs` / `main.rs`
+//!
+//! ```rust, ignore
+//! // only enable unstable feature if it is available and has not yet been stabilised
+//! #![cfg_attr(unstable_assert_matches, feature(assert_matches))]
+//!
+//! #[cfg(test)]
+//! // Do these tests if `assert_matches` is available
+//! #[cfg(has_assert_matches)]
+//! mod tests {
+//!     // `assert_matches` was moved in early 2026 before stabilisation
+//!     #[cfg(assert_matches_location = "root")]
+//!     use std::assert_matches;
+//!
+//!     // in earlier nightly compilers `assert_matches` was in a separate module
+//!     #[cfg(assert_matches_location = "module")]
+//!     use std::assert_matches::assert_matches;
+//!
+//!     #[test]
+//!     fn has() {
+//!         assert_matches!(Some(5), Some(n) if n == 5);
+//!     }
+//! }
+//!
+//! #[cfg(test)]
+//! // Do these tests if `assert_matches` is not available
+//! #[cfg(not(has_assert_matches))]
+//! mod tests {
+//!     #[test]
+//!     fn has_not() {
+//!         assert_eq!(Some(5), Some(5));
+//!     }
+//! }
+//! ```
+//!
+//! ## Note to downstream crates
+//!
+//! If you (transiently) depend on a crate which uses `ninja-build_rs` and have implemented a
+//! whitelist of `allowed-features`.
+//!
+//! Due to limitations in the information provided by cargo:
+//!
+//! - This will obtain config.toml files based upon `OUT_DIR`. If this is not under the project
+//!   root, you can override by providing an alternative path via the environment variable
+//!   `NINJA_CARGO_CONFIG_DIR`. See cargo's documentation on config file hierarchical structure
+//!   for more details.
+//! - This will not respect additional entries passed at the command line via
+//!   `cargo --config unstable.allow-features=[...]`
 
 use std::{
     fmt::Debug,

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -93,7 +93,10 @@ use derive_more::Display;
 use crate::{BuildError, Result, get_var};
 use probes::{has, make_probe};
 
-/// Known features with `unstable_...` & `has_...`
+/// Known features with `unstable_...` & `has_...`.
+/// 
+/// If the feature you want is not in this list you can use `Other` to get `unstable_...`
+/// but please also raise a PR (or open an issue) to add a custom probe for `has_...`.
 #[allow(non_camel_case_types, reason = "shadowing feature naming")]
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum UnstableFeature {

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -632,4 +632,13 @@ use std::assert_matches;
 
         assert_eq!(probes::make_probe(&assert_matches, true, probe), expected);
     }
+
+    #[test]
+    fn unstable_feature_display() {
+        assert_eq!(
+            "foo",
+            format!("{}", UnstableFeature::OtherFeature("foo".to_string()))
+        );
+        assert_eq!("try_trait_v2", format!("{}", UnstableFeature::try_trait_v2))
+    }
 }

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -18,34 +18,36 @@ use probes::{has, make_probe};
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum UnstableFeature {
     /// ### Provides cfg flags:
-    /// - `unstable_assert_matches`
-    /// - `has_assert_matches`
+    /// - `#![cfg_attr(unstable_assert_matches, feature(assert_matches))]`
+    /// - `#[cfg(has_assert_matches)]`
     /// - ```rust, ignore
     ///   #[cfg(assert_matches_location = "root")]
     ///   use std::assert_matches;
+    ///   ```
+    /// - ```rust, ignore
     ///   #[cfg(assert_matches_location = "module")]
     ///   use std::assert_matches::assert_matches;
     ///   ```
     assert_matches,
     /// ### Provides cfg flags:
-    /// - `unstable_iterator_try_collect`
-    /// - `has_iterator_try_collect`
+    /// - `#![cfg_attr(unstable_iterator_try_collect, feature(iterator_try_collect))]`
+    /// - `#[cfg(has_iterator_try_collect)]`
     iterator_try_collect,
     /// ### Provides cfg flags:
-    /// - `unstable_never_type`
-    /// - `has_never_type`
+    /// - `#![cfg_attr(unstable_never_type, feature(never_type))]`
+    /// - `#[cfg(has_never_type)]`
     never_type,
     /// ### Provides cfg flags:
-    /// - `unstable_proc_macro_diagnostic`
-    /// - `has_proc_macro_diagnostic`
+    /// - `#![cfg_attr(unstable_proc_macro_diagnostic, feature(proc_macro_diagnostic))]`
+    /// - `#[cfg(has_proc_macro_diagnostic)]`
     proc_macro_diagnostic,
     /// ### Provides cfg flags:
-    /// - `unstable_try_trait_v2`
-    /// - `has_try_trait_v2`
+    /// - `#![cfg_attr(unstable_try_trait_v2, feature(try_trait_v2))]`
+    /// - `#[cfg(has_try_trait_v2)]`
     try_trait_v2,
     /// ### Provides cfg flags:
-    /// - `unstable_try_trait_v2_residual`
-    /// - `has_try_trait_v2_residual`
+    /// - `#![cfg_attr(unstable_try_trait_v2_residual, feature(try_trait_v2_residual))]`
+    /// - `#[cfg(has_try_trait_v2_residual)]`
     try_trait_v2_residual,
     /// only provides `unstable_...` - please raise a PR to add a custom probe for `has_...`
     OtherFeature(String),

--- a/ninja-build_rs/src/nightly.rs
+++ b/ninja-build_rs/src/nightly.rs
@@ -10,8 +10,7 @@
 //!
 //! ### `build.rs`
 //!
-//! ```rust, ignore
-//! # use autocfg::AutoCfg;
+//! ```rust, should_panic
 //! use ninja_build_rs::prelude::*;
 //!
 //! fn main() -> Result<()> {
@@ -88,7 +87,7 @@ use std::{
     process::{Command, Output},
 };
 
-use autocfg::AutoCfg;
+pub use autocfg::AutoCfg;
 use derive_more::Display;
 
 use crate::{BuildError, Result, get_var};

--- a/ninja-xtask/CHANGELOG.md
+++ b/ninja-xtask/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog ninja-xtask
 
+## v0.3.0
+
+- **Breaking:** remove `From<Vec<Spawned>> for Exit<()>`, replace with `FromIterator<Spawned> for Exit<()>`
+- Also run `cargo test --examples` as part of `stage`
+
 ## v0.2.6
 
 - show stdout and exit status for failed commands

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -228,7 +228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46d9ce1551153dd9b243b10dd0c49e724e0ad63494c1cfb18da2915088726bd7"
 dependencies = [
  "autocfg",
- "ninja-build_rs",
+ "ninja-build_rs 0.2.1",
  "proc-macro2",
  "proc_macro2_diagnostic",
  "quote",
@@ -354,7 +354,16 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ninja-build_rs"
-version = "0.2.2"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491f61b6bc2e8ff020582967a4e7241869c73bcc6d9d84ae6a7cbcb8228a73e4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ninja-build_rs"
+version = "0.3.0"
 dependencies = [
  "autocfg",
 ]
@@ -368,7 +377,7 @@ dependencies = [
  "clap-cargo",
  "dircpy",
  "exit_safely",
- "ninja-build_rs",
+ "ninja-build_rs 0.3.0",
  "tempfile",
  "try_v2",
 ]
@@ -411,7 +420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09381e39ed7a26d59b191fb4466f0ee8c458603b4d92dceb177079c1a9dd22a1"
 dependencies = [
  "autocfg",
- "ninja-build_rs",
+ "ninja-build_rs 0.2.1",
  "proc-macro2",
  "syn",
  "try_v2_traits",
@@ -559,7 +568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66d8e9729eb9fbf4702a26a3d30b9a9b97683a47b352a5e35e74e4a1e9ca6511"
 dependencies = [
  "autocfg",
- "ninja-build_rs",
+ "ninja-build_rs 0.2.1",
  "try_v2_derive",
  "try_v2_traits",
 ]
@@ -571,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4afaedacb5eac11c51ef85fafb90e1c7d4a29fd334104ff3053f065e0c6ee246"
 dependencies = [
  "autocfg",
- "ninja-build_rs",
+ "ninja-build_rs 0.2.1",
  "proc-macro2",
  "proc_macro2_diagnostic",
  "quote",
@@ -585,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54bedaca520dfad05da0a5ac3540651330c1ee9ee11e45bb1d880e3a20c52b9"
 dependencies = [
  "autocfg",
- "ninja-build_rs",
+ "ninja-build_rs 0.2.1",
 ]
 
 [[package]]

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "clap-cargo",
  "dircpy",
  "exit_safely",
+ "ninja-build_rs",
  "tempfile",
  "try_v2",
 ]

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -354,9 +354,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ninja-build_rs"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491f61b6bc2e8ff020582967a4e7241869c73bcc6d9d84ae6a7cbcb8228a73e4"
+version = "0.2.2"
 dependencies = [
  "autocfg",
 ]

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "ninja-xtask"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "autocfg",
  "clap",

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "exit_safely"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3910c73aedf18f9437a2a6f9d73718fe7297223e13a6c87b4c1571b4a557a17"
+checksum = "46d9ce1551153dd9b243b10dd0c49e724e0ad63494c1cfb18da2915088726bd7"
 dependencies = [
  "autocfg",
  "ninja-build_rs",
@@ -354,9 +354,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "ninja-build_rs"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e4803fa657e97ec8ef1789b667f7ff0cb65f0ad1a502b4fb4f9491dea4d6ea"
+checksum = "491f61b6bc2e8ff020582967a4e7241869c73bcc6d9d84ae6a7cbcb8228a73e4"
 dependencies = [
  "autocfg",
 ]
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "proc_macro2_diagnostic"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a91999c599cf46c7b17a4bce5cfdf2aa8197fd53eef6b1aba0c2849b063a9b0"
+checksum = "09381e39ed7a26d59b191fb4466f0ee8c458603b4d92dceb177079c1a9dd22a1"
 dependencies = [
  "autocfg",
  "ninja-build_rs",
@@ -531,9 +531,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "try_v2"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821c7f73c490d0d4347cd4d18c941e7cf44387806029a56a1ebb49ece95e4b0b"
+checksum = "66d8e9729eb9fbf4702a26a3d30b9a9b97683a47b352a5e35e74e4a1e9ca6511"
 dependencies = [
  "autocfg",
  "ninja-build_rs",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "try_v2_derive"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64edd76412d03149a4a4402fbe91a91efde74d47adc93e38be523625c0d8827"
+checksum = "4afaedacb5eac11c51ef85fafb90e1c7d4a29fd334104ff3053f065e0c6ee246"
 dependencies = [
  "autocfg",
  "ninja-build_rs",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "try_v2_traits"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29330520c46c1e1f0d03cef0e64adbb71d57dab06df1cc776a4ab1b4201fff9c"
+checksum = "d54bedaca520dfad05da0a5ac3540651330c1ee9ee11e45bb1d880e3a20c52b9"
 dependencies = [
  "autocfg",
  "ninja-build_rs",

--- a/ninja-xtask/Cargo.lock
+++ b/ninja-xtask/Cargo.lock
@@ -133,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +196,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
 
 [[package]]
 name = "dircpy"
@@ -366,6 +398,7 @@ name = "ninja-build_rs"
 version = "0.3.0"
 dependencies = [
  "autocfg",
+ "derive_more",
 ]
 
 [[package]]
@@ -459,6 +492,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -602,6 +644,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -30,4 +30,7 @@ tempfile = "3.27.0"
 
 [build-dependencies]
 autocfg = "1.5.1"
-ninja-build_rs = "0.2.1"
+ninja-build_rs = "0.2.2"
+
+[patch.crates-io]
+ninja-build_rs.path = "../ninja-build_rs"

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -21,8 +21,8 @@ pkg-url = "{ repo }/releases/download/{ name }_v{ version }/{ name }-{ target }-
 [dependencies]
 clap = { version = "4.6.0", features = ["derive"] }
 clap-cargo = "0.18.3"
-exit_safely = "0.3.2"
-try_v2 = "0.8.0"
+exit_safely = "0.3.3"
+try_v2 = "0.9.2"
 
 [dev-dependencies]
 dircpy = "0.3.20"

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-xtask"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2024"
 readme = "README.md"
 description = "xtask utilities that I use in most projects"

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -30,7 +30,7 @@ tempfile = "3.27.0"
 
 [build-dependencies]
 autocfg = "1.5.1"
-ninja-build_rs = "0.2.2"
+ninja-build_rs = "0.3.0"
 
 [patch.crates-io]
 ninja-build_rs.path = "../ninja-build_rs"

--- a/ninja-xtask/Cargo.toml
+++ b/ninja-xtask/Cargo.toml
@@ -30,3 +30,4 @@ tempfile = "3.27.0"
 
 [build-dependencies]
 autocfg = "1.5.1"
+ninja-build_rs = "0.2.1"

--- a/ninja-xtask/build.rs
+++ b/ninja-xtask/build.rs
@@ -4,9 +4,9 @@ fn main() -> Result<()> {
     let allowed_features = cargo_allowed_features()?;
     let ac = autocfg::new();
 
-    ac.emit_unstable_feature("never_type", &allowed_features);
-    ac.emit_unstable_feature("try_trait_v2", &allowed_features);
-    ac.emit_unstable_feature("try_trait_v2_residual", &allowed_features);
+    ac.emit_unstable_feature(never_type, &allowed_features);
+    ac.emit_unstable_feature(try_trait_v2, &allowed_features);
+    ac.emit_unstable_feature(try_trait_v2_residual, &allowed_features);
 
     Ok(())
 }

--- a/ninja-xtask/build.rs
+++ b/ninja-xtask/build.rs
@@ -1,7 +1,4 @@
-use ninja_build_rs::{
-    Result,
-    nightly::{Nightly, cargo_allowed_features},
-};
+use ninja_build_rs::prelude::*;
 
 fn main() -> Result<()> {
     let allowed_features = cargo_allowed_features()?;

--- a/ninja-xtask/build.rs
+++ b/ninja-xtask/build.rs
@@ -1,0 +1,15 @@
+use ninja_build_rs::{
+    Result,
+    nightly::{Nightly, cargo_allowed_features},
+};
+
+fn main() -> Result<()> {
+    let allowed_features = cargo_allowed_features()?;
+    let ac = autocfg::new();
+
+    ac.emit_unstable_feature("never_type", &allowed_features);
+    ac.emit_unstable_feature("try_trait_v2", &allowed_features);
+    ac.emit_unstable_feature("try_trait_v2_residual", &allowed_features);
+
+    Ok(())
+}

--- a/ninja-xtask/src/commands.rs
+++ b/ninja-xtask/src/commands.rs
@@ -53,6 +53,17 @@ pub fn test(root: &Path) -> Spawned {
         .into_spawned("tests")
 }
 
+pub fn test_examples(root: &Path) -> Spawned {
+    Command::new("cargo")
+        .current_dir(root)
+        .arg("test")
+        .arg("--examples")
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .into_spawned("test examples")
+}
+
 /// Spawn `cargo build` (if no `glibc` specified) / `cargo zigbuild` (if `target` or `glibc`
 /// specified) optionally performing a release build (default is cargo's default profile).
 ///

--- a/ninja-xtask/src/lib.rs
+++ b/ninja-xtask/src/lib.rs
@@ -137,8 +137,8 @@ impl SpawnedExt for Result<Child, io::Error> {
     }
 }
 
-impl From<Vec<Spawned>> for Exit<()> {
-    fn from(spawns: Vec<Spawned>) -> Self {
+impl FromIterator<Spawned> for Exit<()> {
+    fn from_iter<I: IntoIterator<Item = Spawned>>(spawns: I) -> Self {
         spawns
             .into_iter()
             .map(|spawn| spawn.wait())

--- a/ninja-xtask/src/lib.rs
+++ b/ninja-xtask/src/lib.rs
@@ -9,11 +9,12 @@ use std::{
 };
 
 use exit_safely::Termination;
-use try_v2::{Try, Try_ConvertResult};
+use try_v2::Try;
 
 pub mod commands;
 
-#[derive(Debug, Termination, Try, Try_ConvertResult, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Termination, Try, PartialEq, PartialOrd, Eq, Ord)]
+#[FromResidual(Result<_, Self::Residual>)]
 #[repr(u8)]
 #[must_use]
 pub enum Exit<T: _T> {

--- a/ninja-xtask/src/lib.rs
+++ b/ninja-xtask/src/lib.rs
@@ -1,6 +1,6 @@
-#![feature(never_type)]
-#![feature(try_trait_v2)]
-#![feature(try_trait_v2_residual)]
+#![cfg_attr(unstable_never_type, feature(never_type))]
+#![cfg_attr(unstable_try_trait_v2, feature(try_trait_v2))]
+#![cfg_attr(unstable_try_trait_v2_residual, feature(try_trait_v2_residual))]
 
 use std::{
     fmt::Debug,

--- a/ninja-xtask/src/main.rs
+++ b/ninja-xtask/src/main.rs
@@ -43,11 +43,12 @@ fn main() -> Exit<()> {
         Command::Stage => {
             let fmt = fmt(root);
             Exit::from(fmt)?;
-            let clippy = clippy(root);
-            let clippy_tests = clippy_tests(root);
-            let tests = test(root);
-            let test_examples = test_examples(root);
-            let checks = vec![clippy, clippy_tests, tests, test_examples];
+            let checks = [
+                clippy(root),
+                clippy_tests(root),
+                test(root),
+                test_examples(root),
+            ];
             Exit::from_iter(checks)?;
             let git = git_add(root);
             Exit::from(git)

--- a/ninja-xtask/src/main.rs
+++ b/ninja-xtask/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 use clap_cargo::style::CLAP_STYLING as CARGO_STYLING;
 use ninja_xtask::{
     Exit,
-    commands::{build, clippy, clippy_tests, fmt, git_add, test},
+    commands::{build, clippy, clippy_tests, fmt, git_add, test, test_examples},
 };
 
 #[derive(Parser)]
@@ -46,7 +46,8 @@ fn main() -> Exit<()> {
             let clippy = clippy(root);
             let clippy_tests = clippy_tests(root);
             let tests = test(root);
-            let checks = vec![clippy, clippy_tests, tests];
+            let test_examples = test_examples(root);
+            let checks = vec![clippy, clippy_tests, tests, test_examples];
             Exit::from(checks)?;
             let git = git_add(root);
             Exit::from(git)

--- a/ninja-xtask/src/main.rs
+++ b/ninja-xtask/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> Exit<()> {
             let tests = test(root);
             let test_examples = test_examples(root);
             let checks = vec![clippy, clippy_tests, tests, test_examples];
-            Exit::from(checks)?;
+            Exit::from_iter(checks)?;
             let git = git_add(root);
             Exit::from(git)
         }

--- a/ninja-xtask/src/main.rs
+++ b/ninja-xtask/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Exit<()> {
         Command::Stage => {
             let fmt = fmt(root);
             Exit::from(fmt)?;
+
             let checks = [
                 clippy(root),
                 clippy_tests(root),
@@ -50,6 +51,7 @@ fn main() -> Exit<()> {
                 test_examples(root),
             ];
             Exit::from_iter(checks)?;
+
             let git = git_add(root);
             Exit::from(git)
         }


### PR DESCRIPTION
## ninja-build_rs
- prelude
- require Unstable_Feature variant rather than &str for all functions
- re-export autocfg::AutoCfg

## ninja-xtask
- **Breaking:** remove `From<Vec<Spawned>> for Exit<()>`, replace with `FromIterator<Spawned> for Exit<()>`
- Also run `cargo test --examples` as part of `stage`